### PR TITLE
Generate installable artifact

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,6 +11,7 @@ app:
   envs:
   - PROJECT_LOCATION: .
   - MODULE: app
+  - VARIANT: debug
   - GRADLEW_PATH: ./gradlew
 workflows:
   _setup:
@@ -36,15 +37,11 @@ workflows:
         - cache_level: all
         - variant: $VARIANT
   primary:
-    envs:
-    - VARIANT: debug
     before_run:
     - _test
     steps:
     - deploy-to-bitrise-io@2: {}
   deploy-demo:
-    envs:
-    - VARIANT: debug
     before_run:
     - _test
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -27,22 +27,24 @@ workflows:
         - project_location: $PROJECT_LOCATION
         - module: $MODULE
         - cache_level: all
-        - variant: $BUILD_VARIANT
+        - variant: $VARIANT
     - android-unit-test@1:
         inputs:
         - project_location: $PROJECT_LOCATION
         - module: $MODULE
         - arguments: ''
         - cache_level: all
-        - variant: $BUILD_VARIANT
+        - variant: $VARIANT
   primary:
+    envs:
+    - VARIANT: debug
     before_run:
     - _test
     steps:
     - deploy-to-bitrise-io@2: {}
   deploy-demo:
     envs:
-    - BUILD_VARIANT: debug
+    - VARIANT: debug
     before_run:
     - _test
     steps:
@@ -52,7 +54,7 @@ workflows:
         - project_location: $PROJECT_LOCATION
         - module: $MODULE
         - build_type: apk
-        - variant: $BUILD_VARIANT
+        - variant: $VARIANT
     - deploy-to-bitrise-io@2:
         inputs:
         - notify_user_groups: none
@@ -111,7 +113,7 @@ workflows:
       The next change in your repository that matches any of your trigger map
       event will start **deploy** workflow.
     envs:
-    - BUILD_VARIANT: release
+    - VARIANT: release
     before_run:
     - _test
     steps:
@@ -120,7 +122,7 @@ workflows:
         - project_location: $PROJECT_LOCATION
         - module: $MODULE
         - build_type: aab
-        - variant: $BUILD_VARIANT
+        - variant: $VARIANT
     - sign-apk@1:
         run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,28 +11,48 @@ app:
   envs:
   - PROJECT_LOCATION: .
   - MODULE: app
-  - VARIANT: ''
   - GRADLEW_PATH: ./gradlew
 workflows:
-  primary:
+  _setup:
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@8: {}
-    - restore-gradle-cache@1: {}
+  _test:
+    before_run:
+    - _setup
+    steps:
     - android-lint@0:
         inputs:
         - project_location: $PROJECT_LOCATION
-        - module: app
+        - module: $MODULE
         - cache_level: all
-        - variant: debug
+        - variant: $BUILD_VARIANT
     - android-unit-test@1:
         inputs:
         - project_location: $PROJECT_LOCATION
-        - module: app
+        - module: $MODULE
         - arguments: ''
         - cache_level: all
-        - variant: debug
+        - variant: $BUILD_VARIANT
+  primary:
+    before_run:
+    - _test
+    steps:
+    - deploy-to-bitrise-io@2: {}
+  deploy-demo:
+    envs:
+    - BUILD_VARIANT: debug
+    before_run:
+    - _test
+    steps:
+    - restore-gradle-cache@1: {}
+    - android-build@0:
+        inputs:
+        - project_location: $PROJECT_LOCATION
+        - module: $MODULE
+        - build_type: apk
+        - variant: $BUILD_VARIANT
     - deploy-to-bitrise-io@2:
         inputs:
         - notify_user_groups: none
@@ -90,26 +110,17 @@ workflows:
 
       The next change in your repository that matches any of your trigger map
       event will start **deploy** workflow.
+    envs:
+    - BUILD_VARIANT: release
+    before_run:
+    - _test
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@6: {}
-    - android-lint@0:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $MODULE
-        - variant: release
-    - android-unit-test@1:
-        inputs:
-        - project_location: $PROJECT_LOCATION
-        - module: $MODULE
-        - variant: release
     - android-build@0:
         inputs:
         - project_location: $PROJECT_LOCATION
         - module: $MODULE
         - build_type: aab
-        - variant: release
+        - variant: $BUILD_VARIANT
     - sign-apk@1:
         run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
         inputs:


### PR DESCRIPTION
## Context
\[[PLG-1349]\] We want demo app builds to generate artifacts of the executable apps for installation on mobile devices as well as export test reports.

## Changes
* Introduced `_setup` and `test` utility workflows in order to reduce repeated steps across workflows
* Made `primary` workflow use new `_test` utility workflow and deploy
* Modified `deploy` workflow to utilize the new `_test` utility workflow and generate a release app package
* Added `deploy-demo` to run tests and generate a debug simulator app package
* Added a trigger map to kick off primary workflow

## Decisions
* Kept a separate `_test` workflow in order to prevent deploying twice in `primary`, `deploy-demo`, and `deploy` workflows (once would be for test and a second time for the app artifact)
  * `deploy-demo`, `primary`, and `deploy` all execute the `_test` workflow then later have a deploy step

[PLG-1349]: https://bitrise.atlassian.net/browse/PLG-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ